### PR TITLE
Use history mode on router

### DIFF
--- a/src/404.js
+++ b/src/404.js
@@ -1,0 +1,1 @@
+import "@/main";

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,7 @@ Vue.use(Router);
 
 export default new Router({
   base: process.env.BASE_URL,
+  mode: "history",
   routes: [
     {
       path: "/",

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-  baseUrl: process.env.NODE_ENV === "production" ? "/gitlab-teams/" : "/"
+  baseUrl: process.env.NODE_ENV === "production" ? "/gitlab-teams/" : "/",
+  pages: {
+    index: "src/main.js",
+    404: "src/404.js"
+  }
 };


### PR DESCRIPTION
This PR features a hack to resolve routing errors on Github pages (see #7). The hack is basically to still serve the application in case of a 404. Upon build, a `404.html` will be generated which is basically a copy of `index.html`. In case of an inexistant route, GH pages will serve `404.html` which is the application and routing will be done front-end.

HTML 5 routing mode is necessary for OAuth autorization since the redirect URL is given in URL `#` can't be used in redirect URL.