### PR TITLE
Made the lists on the Issues and Merge Requests page responsive.

### DIFF
--- a/src/components/Issue.vue
+++ b/src/components/Issue.vue
@@ -35,7 +35,7 @@
     </v-list-tile-content>
 
     <v-list-tile-action v-if="!hideActions">
-      <div id="actions">
+      <div id="actions" v-if="$vuetify.breakpoint.mdAndUp">
         <v-badge class="pr-2" overlap left color="orange">
           <span slot="badge">{{ item.user_notes_count }}</span>
           <v-icon>chat</v-icon>
@@ -48,6 +48,31 @@
           <span slot="badge">{{ item.downvotes }}</span>
           <v-icon>thumb_down</v-icon>
         </v-badge>
+      </div>
+      <div v-else>
+        <v-menu offset-y min-width="150">
+            <v-btn icon ripple slot="activator" @click.native.prevent>
+                <v-icon color="grey darken-1">more_vert</v-icon>
+            </v-btn>
+            <div id="actions">
+            <v-list>
+                <v-list-tile>
+                    <v-badge class="pr-2" overlap left color="orange">
+                    <span slot="badge">{{ item.user_notes_count }}</span>
+                    <v-icon>chat</v-icon>
+                    </v-badge>
+                    <v-badge class="pr-2" overlap left color="orange">
+                    <span slot="badge">{{ item.upvotes }}</span>
+                    <v-icon>thumb_up</v-icon>
+                    </v-badge>
+                    <v-badge class="pr-2" overlap left color="orange">
+                    <span slot="badge">{{ item.downvotes }}</span>
+                    <v-icon>thumb_down</v-icon>
+                    </v-badge>
+                </v-list-tile>
+            </v-list>
+            </div>
+        </v-menu>
       </div>
     </v-list-tile-action>
   </v-list-tile>

--- a/src/components/Issue.vue
+++ b/src/components/Issue.vue
@@ -51,27 +51,27 @@
       </div>
       <div v-else>
         <v-menu offset-y min-width="150">
-            <v-btn icon ripple slot="activator" @click.native.prevent>
-                <v-icon color="grey darken-1">more_vert</v-icon>
-            </v-btn>
-            <div id="actions">
+          <v-btn icon ripple slot="activator" @click.native.prevent>
+              <v-icon color="grey darken-1">more_vert</v-icon>
+          </v-btn>
+          <div id="actions">
             <v-list>
-                <v-list-tile>
-                    <v-badge class="pr-2" overlap left color="orange">
-                    <span slot="badge">{{ item.user_notes_count }}</span>
-                    <v-icon>chat</v-icon>
-                    </v-badge>
-                    <v-badge class="pr-2" overlap left color="orange">
-                    <span slot="badge">{{ item.upvotes }}</span>
-                    <v-icon>thumb_up</v-icon>
-                    </v-badge>
-                    <v-badge class="pr-2" overlap left color="orange">
-                    <span slot="badge">{{ item.downvotes }}</span>
-                    <v-icon>thumb_down</v-icon>
-                    </v-badge>
-                </v-list-tile>
+              <v-list-tile>
+                <v-badge class="pr-2" overlap left color="orange">
+                  <span slot="badge">{{ item.user_notes_count }}</span>
+                  <v-icon>chat</v-icon>
+                </v-badge>
+                <v-badge class="pr-2" overlap left color="orange">
+                  <span slot="badge">{{ item.upvotes }}</span>
+                  <v-icon>thumb_up</v-icon>
+                </v-badge>
+                <v-badge class="pr-2" overlap left color="orange">
+                  <span slot="badge">{{ item.downvotes }}</span>
+                  <v-icon>thumb_down</v-icon>
+                </v-badge>
+              </v-list-tile>
             </v-list>
-            </div>
+          </div>
         </v-menu>
       </div>
     </v-list-tile-action>

--- a/src/components/MergeRequestItem.vue
+++ b/src/components/MergeRequestItem.vue
@@ -40,7 +40,7 @@
     </v-list-tile-content>
 
     <v-list-tile-action>
-      <div id="actions">
+      <div id="actions" v-if="$vuetify.breakpoint.mdAndUp">
         <v-badge class="pr-2" overlap left>
           <span slot="badge">{{ mr.user_notes_count }}</span>
           <v-icon>chat</v-icon>
@@ -65,6 +65,66 @@
             <v-icon color="grey darken-1">more_vert</v-icon>
           </v-btn>
           <v-list>
+            <v-list-tile :href="mr.web_url" target="_blank">
+              <v-list-tile-title>View on GitLab</v-list-tile-title>
+            </v-list-tile>
+            <v-list-tile @click="createTodo()">
+              <v-list-tile-title>Create Todo</v-list-tile-title>
+            </v-list-tile>
+            <v-list-tile v-if="canBeClosed" @click="close()">
+              <v-list-tile-title>Close MR</v-list-tile-title>
+            </v-list-tile>
+            <v-list-tile @click="copyLink()">
+              <v-list-tile-title>Copy link</v-list-tile-title>
+            </v-list-tile>
+            <v-list-tile @click="showMore=true">
+              <v-list-tile-title>Show more...</v-list-tile-title>
+              <v-dialog v-model="showMore" max-width="800px" lazy>
+                <v-card>
+                  <v-card-title primary-title>
+                    <h3>{{ mr.title }}</h3>
+                  </v-card-title>
+                  <v-card-text>
+                    <merge-request-details :mr="mr"/>
+                  </v-card-text>
+                  <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn color="primary" flat @click="showMore=false">Close</v-btn>
+                  </v-card-actions>
+                </v-card>
+              </v-dialog>
+            </v-list-tile>
+          </v-list>
+        </v-menu>
+      </div>
+      <div v-else>
+        <v-menu offset-y min-width="150">
+          <v-btn icon ripple slot="activator" @click.native.prevent>
+            <v-icon color="grey darken-1">more_vert</v-icon>
+          </v-btn>
+          <v-list>
+            <v-list-tile>
+              <v-badge class="pr-2" overlap left>
+                <span slot="badge">{{ mr.user_notes_count }}</span>
+                <v-icon>chat</v-icon>
+              </v-badge>
+              <v-badge class="pr-2" overlap left>
+                <span slot="badge">{{ mr.upvotes }}</span>
+                <v-icon>thumb_up</v-icon>
+              </v-badge>
+              <v-tooltip top>
+                <v-btn class="mr-3" icon small
+                  slot="activator"
+                  @click.prevent="merge()"
+                  :disabled="merging || closing || mr.work_in_progress || mr.merge_status !== 'can_be_merged' || mr.state !== 'opened'"
+                  :loading="merging"
+                >
+                  <v-icon>merge_type</v-icon>
+                </v-btn>
+                <span>Merge it</span>
+              </v-tooltip>
+            </v-list-tile>
+            <v-divider></v-divider>
             <v-list-tile :href="mr.web_url" target="_blank">
               <v-list-tile-title>View on GitLab</v-list-tile-title>
             </v-list-tile>

--- a/src/components/MergeRequestItem.vue
+++ b/src/components/MergeRequestItem.vue
@@ -112,15 +112,11 @@
                 <span slot="badge">{{ mr.upvotes }}</span>
                 <v-icon>thumb_up</v-icon>
               </v-badge>
-              <v-btn class="mr-3" small flat
-                @click.prevent="merge()"
-                :disabled="merging || closing || mr.work_in_progress || mr.merge_status !== 'can_be_merged' || mr.state !== 'opened'"
-                :loading="merging"
-              >
-                Merge
-              </v-btn>
             </v-list-tile>
             <v-divider></v-divider>
+            <v-list-tile @click.prevent="merge()" :disabled="merging || closing || mr.work_in_progress || mr.merge_status !== 'can_be_merged' || mr.state !== 'opened'">
+              Merge
+            </v-list-tile>
             <v-list-tile :href="mr.web_url" target="_blank">
               <v-list-tile-title>View on GitLab</v-list-tile-title>
             </v-list-tile>

--- a/src/components/MergeRequestItem.vue
+++ b/src/components/MergeRequestItem.vue
@@ -112,17 +112,13 @@
                 <span slot="badge">{{ mr.upvotes }}</span>
                 <v-icon>thumb_up</v-icon>
               </v-badge>
-              <v-tooltip top>
-                <v-btn class="mr-3" icon small
-                  slot="activator"
-                  @click.prevent="merge()"
-                  :disabled="merging || closing || mr.work_in_progress || mr.merge_status !== 'can_be_merged' || mr.state !== 'opened'"
-                  :loading="merging"
-                >
-                  <v-icon>merge_type</v-icon>
-                </v-btn>
-                <span>Merge it</span>
-              </v-tooltip>
+              <v-btn class="mr-3" small flat
+                @click.prevent="merge()"
+                :disabled="merging || closing || mr.work_in_progress || mr.merge_status !== 'can_be_merged' || mr.state !== 'opened'"
+                :loading="merging"
+              >
+                Merge
+              </v-btn>
             </v-list-tile>
             <v-divider></v-divider>
             <v-list-tile :href="mr.web_url" target="_blank">


### PR DESCRIPTION
To correct issue #66 I used Vuetify's built-in breakpoints to determine the following:

- If the screen size is medium and above, it will display the original way with all icons showing.
- If the screen size is small and below, instead of showing multiple icons, it will display the vertical dots icon.


When you click the vertical dots icon on the Issues page, it will show a popup menu list that shows the icons for thumbs up, thumbs down, and comments.

When you click the vertical dots icon on the Merge Requests page, it will show the same popup menu list as before with the options to View on Gitlab, Create Todo, etc., but now at the top of the list it shows the thumbs up, thumbs down, and merge icons.


The list item component built into Vuetify automatically adds ellipses to text when the text gets too long, but in this instance, it was actually the content in the "v-list-tile-action" component (the multiple icons) that was extending outside its box and overlapping on top of the list's text content, so I thought it would look nicer if it was all under one icon that expands to show the icons.  Let me know what you think about it.