### PR TITLE
#102 Assigned Merge Requests with desktop notification

### DIFF
--- a/src/components/MergeRequestItem.vue
+++ b/src/components/MergeRequestItem.vue
@@ -18,7 +18,7 @@
       </v-list-tile-sub-title>
       <v-list-tile-sub-title>
         <div id="subtitle">
-          {{ getProject(mr.project_id).name }}!{{ mr.iid }} - {{ mr.source_branch }} into {{ mr.target_branch }}
+          {{ getProject(mr.project_id) && getProject(mr.project_id).name }}!{{ mr.iid }} - {{ mr.source_branch }} into {{ mr.target_branch }}
           <div class="ml-1" v-if="mr.assignee">
             <v-tooltip bottom>
               <v-avatar size="16" slot="activator">

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -68,6 +68,10 @@ function init(store) {
     store.dispatch("newAssignedMergeRequest", mr);
   });
 
+  gitlabApi.on("removed-assigned-mr", mr => {
+    store.dispatch("removeAssignedMergeRequest", mr);
+  });
+
   gitlabApi.on("new-assigned-mr-length", size => {
     store.dispatch("setAssignedMergeRequestSize", size);
   });

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -60,6 +60,17 @@ function init(store) {
   gitlabApi.on("new-runner", runner => {
     store.dispatch("addRunner", runner);
   });
+
+  gitlabApi.on("new-assigned-mr", ({ mr, notify = false }) => {
+    if (notify) {
+      notification.notify("mr-assigned", `New assigned MR - ${mr.title}`);
+    }
+    store.dispatch("newAssignedMergeRequest", mr);
+  });
+
+  gitlabApi.on("new-assigned-mr-length", size => {
+    store.dispatch("setAssignedMergeRequestSize", size);
+  });
 }
 
 function get() {

--- a/src/services/gitlab/client.js
+++ b/src/services/gitlab/client.js
@@ -40,14 +40,22 @@ export default class Client {
   }
 
   fetchMergeRequests({ state = "opened", author_id }) {
-    // TODO: Use axios query params
-    let endpoint = `/api/v4/merge_requests?state=${state}`;
+    return this.client.get("/api/v4/merge_requests", {
+      params: {
+        state,
+        author_id,
+        scope: author_id ? "all" : undefined
+      }
+    });
+  }
 
-    if (author_id) {
-      endpoint = `${endpoint}&scope=all&author_id=${author_id}`;
-    }
-
-    return this.client.get(endpoint);
+  fetchAssignedMergeRequests({ state = "opened" } = {}) {
+    return this.client.get("/api/v4/merge_requests", {
+      params: {
+        state,
+        scope: "assigned_to_me"
+      }
+    });
   }
 
   fetchMergeRequest(projectId, iid) {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -33,6 +33,7 @@ export const launchUserWatchers = ({ dispatch }) => {
 
   dispatch("fetchConnectedUser");
   gl.watchTodos();
+  gl.watchAssignedMergeRequests();
   gl.watchIssues();
   gl.watchProjects();
   gl.watchRunners();

--- a/src/store/modules/merge_request.js
+++ b/src/store/modules/merge_request.js
@@ -50,6 +50,10 @@ const actions = {
     commit("addAssignedMergeRequest", mr);
   },
 
+  removeAssignedMergeRequest({ commit }, mr) {
+    commit("removeAssignedMergeRequest", mr);
+  },
+
   setAssignedMergeRequestSize({ commit }, size) {
     commit("setAssignedMergeRequestSize", size);
   }
@@ -99,6 +103,10 @@ const mutations = {
 
   addAssignedMergeRequest({ assignedMergeRequests }, mergeRequest) {
     Vue.set(assignedMergeRequests, mergeRequest.id, mergeRequest);
+  },
+
+  removeAssignedMergeRequest({ assignedMergeRequests }, mergeRequest) {
+    Vue.delete(assignedMergeRequests, mergeRequest.id, mergeRequest);
   },
 
   setAssignedMergeRequestSize(state, size) {

--- a/src/store/modules/merge_request.js
+++ b/src/store/modules/merge_request.js
@@ -2,7 +2,9 @@ import Vue from "vue";
 import gitlab from "@/gitlab";
 
 const state = {
-  mergeRequests: {}
+  mergeRequests: {},
+  assignedMergeRequests: {},
+  assignedMergeRequestsSize: 0
 };
 
 const actions = {
@@ -42,6 +44,14 @@ const actions = {
 
   updateMergeRequest({ commit }, mr) {
     commit("updateMergeRequest", mr);
+  },
+
+  newAssignedMergeRequest({ commit }, mr) {
+    commit("addAssignedMergeRequest", mr);
+  },
+
+  setAssignedMergeRequestSize({ commit }, size) {
+    commit("setAssignedMergeRequestSize", size);
   }
 };
 
@@ -59,6 +69,10 @@ const getters = {
 
   getMergeRequests({ mergeRequests }) {
     return Object.values(mergeRequests);
+  },
+
+  getAssignedMergeRequests({ assignedMergeRequests }) {
+    return Object.values(assignedMergeRequests);
   }
 };
 
@@ -81,6 +95,14 @@ const mutations = {
 
   updateMergeRequest({ mergeRequests }, mergeRequest) {
     Vue.set(mergeRequests, mergeRequest.id, mergeRequest);
+  },
+
+  addAssignedMergeRequest({ assignedMergeRequests }, mergeRequest) {
+    Vue.set(assignedMergeRequests, mergeRequest.id, mergeRequest);
+  },
+
+  setAssignedMergeRequestSize(state, size) {
+    state.assignedMergeRequestsSize = parseInt(size);
   }
 };
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,6 +24,7 @@ export default {
     ...mapGetters({
       getDashboard: "dashboard/getDashboard",
       mergeRequests: "getMergeRequests",
+      assignedMergeRequests: "getAssignedMergeRequests",
       user: "getConnectedUser",
       issues: "getIssues",
       issuesSize: "getIssuesSize",
@@ -56,6 +57,14 @@ export default {
           component: MergeRequestsCard,
           props: { mergeRequests: this.mergeRequests },
           columns: 3
+        },
+        "assigned-mrs": {
+          id: "assigned-mrs",
+          title: "Assigned Merge Requests",
+          icon: "merge_type",
+          component: MergeRequestsCard,
+          props: { mergeRequests: this.assignedMergeRequests },
+          columns: 2
         },
         stats: {
           id: "stats",
@@ -108,7 +117,12 @@ export default {
         return Object.values(this.cards);
       }
 
-      return dashboard.cards.map(e => this.cards[e]).filter(Boolean);
+      const allKeys = Object.keys(this.cards);
+      const remaining = allKeys.filter(x => !dashboard.cards.includes(x));
+
+      return [...dashboard.cards, ...remaining]
+        .map(e => this.cards[e])
+        .filter(Boolean);
     }
   },
   methods: {

--- a/src/views/MergeRequests.vue
+++ b/src/views/MergeRequests.vue
@@ -4,18 +4,29 @@
       <v-tab key="open">
         Open
       </v-tab>
+      <v-tab key="assigned">
+        <v-badge right>
+          <span slot="badge">{{assignedMergeRequestsSize}}</span>
+          <span>Assigned to me</span>
+        </v-badge>
+      </v-tab>
       <v-tab key="merged" @click="fetchData('merged')">
         Merged
       </v-tab>
       <v-tab key="closed" @click="fetchData('closed')">
         Closed
       </v-tab>
-      <v-layout v-show="activeTab !== 0" justify-end>
+      <v-layout v-show="activeTab > 1" justify-end>
         <item-order-select v-model="mergeRequestsOrder" :options="mergeRequestsOrderOptions"/>
       </v-layout>
       <v-tab-item key="open">
         <template>
           <merge-requests :merge-requests="computedMergeRequests"/>
+        </template>
+      </v-tab-item>
+      <v-tab-item key="assigned">
+        <template>
+          <merge-requests :merge-requests="assignedMergeRequests"/>
         </template>
       </v-tab-item>
       <v-tab-item key="merged">
@@ -43,7 +54,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapState } from "vuex";
 import gitlab from "@/gitlab";
 import store from "@/store";
 import ItemOrderSelect from "@/components/ItemOrderSelect.vue";
@@ -73,7 +84,11 @@ export default {
   },
   computed: {
     ...mapGetters({
-      computedMergeRequests: "getMergeRequests"
+      computedMergeRequests: "getMergeRequests",
+      assignedMergeRequests: "getAssignedMergeRequests"
+    }),
+    ...mapState({
+      assignedMergeRequestsSize: state => state.merge_request.assignedMergeRequestsSize
     })
   },
   // TODO: need to fetch the right ones on mount or route change because if you come from a team you will get the team ones displayed here


### PR DESCRIPTION
Adds support to assigned merge requests for current user as defined in #102 

- Display new widget in dashboard
- Display new tab in MR page
- Display a desktop notification when a MR is assigned. For now does not work when a MR is unassigned then reassigned. Will come later, as for other event types.