### PR TITLE
Handle notifications when merging MRs

### DIFF
--- a/src/components/MergeRequestItem.vue
+++ b/src/components/MergeRequestItem.vue
@@ -216,10 +216,11 @@ export default {
       this.merging = true;
       this.$store
         .dispatch("merge", this.mr)
-        .then(() => {})
-        .catch(err => {
-          // TODO: MR can not be merged
-          console.log(err);
+        .then(() => {
+          this.$store.dispatch("displaySnackbarMessage", "MR successfully merged")
+        })
+        .catch(() => {
+          this.$store.dispatch("displaySnackbarMessage", "Error while merging MR")
         })
         .finally(() => {
           this.merging = false;


### PR DESCRIPTION
Hey !

I figured I'd add two snackbar notifications (_success_ and _error_) when trying to merge Mrs, there's no real error handling per se, but its a start (helps a bit with #16 )

If you want to try it out I suggest you mock a failed api call in `merge_request.js`  inside the `merge `action with
```
merge({ dispatch }, mr) {
    return Promise.reject(new Error('fake error'))
    // const gl = gitlab.get();
    //
    // return gl.client.merge(mr).then(() => {
    //   dispatch("removeMergeRequest", mr);
    //   // TODO: Stop watchers for this MR
    // });
  }
```

Don't hesitate to suggest changes or offer feedback :)